### PR TITLE
chore: prepare v0.18.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2026-03-10
+
+### Added
+- Unified item architecture (`ManagedItem`) with shared `ItemList`, `ItemDetail`, and centralized action dispatch.
+- Unified marketplace presentation for plugin and Pi marketplace rows/details.
+- Plugin pullback actions for drifted instances (`Pull to source from <instance>`) with aligned `p` shortcuts in detail and diff views.
+- Installed tab loading placeholders for all sections (Files, Plugins, Pi Packages).
+
+### Changed
+- Refresh model is now startup scan + manual refresh (`R`) only (removed navigation-triggered and watcher-driven auto-refresh behavior).
+- Source repo status is prewarmed/cached for faster Settings rendering.
+- Sync-tab plugin drilldown via `d` now opens plugin detail to match other detail-first workflows.
+
+### Fixed
+- "Install to Pi" for local source-repo marketplaces now resolves plugin sources relative to repo root when marketplace is under `.claude-plugin/`.
+- Per-tool plugin install/uninstall actions correctly target intended instances in unified dispatch.
+- Plugin update behavior now only updates instances where plugin is already installed.
+- Drift display consistency fixes: suppress noisy `Changed +0 -0` and only mark changed when per-instance diffs exist.
+
 ## [0.17.2] - 2026-03-02
 
 ### Added
@@ -452,7 +471,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Symlink handling for plugin assets
 
-[Unreleased]: https://github.com/ssweens/blackbook/compare/v0.17.2...HEAD
+[Unreleased]: https://github.com/ssweens/blackbook/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/ssweens/blackbook/compare/v0.17.2...v0.18.0
 [0.17.2]: https://github.com/ssweens/blackbook/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/ssweens/blackbook/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/ssweens/blackbook/compare/v0.16.1...v0.17.0

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Everything is a plugin. Plugins can include skills, commands, agents, hooks, MCP
 | OpenAI Codex | `~/.codex` | ✓ | — | — | ✓ |
 | OpenCode | `~/.config/opencode` | ✓ | ✓ | ✓ | ✓ |
 | Amp Code | `~/.config/amp` | ✓ | ✓ | ✓ | ✓ |
-| Pi | `~/.pi` | ✓ | ✓* | — | ✓ |
+| Pi | `~/.pi/agent` | ✓ | ✓* | — | ✓ |
 
 \* Pi uses `agent/skills/` for skills and `agent/prompts/` for prompt templates (`/name` syntax)
 
@@ -103,7 +103,7 @@ Blackbook opens on the **Sync** tab by default.
 - **Tools**: `Enter` open detail, `i` install, `u` update, `d` uninstall, `Space` toggle enabled, `e` edit config dir, `R` refresh detection
 - **Sync**: `y` sync selected items (missing plus `source-changed` / `target-changed` / `both-changed` files/plugins and tool updates; press twice to confirm), `R` refresh sync inputs
 
-Blackbook also refreshes data when entering tabs (Discover, Installed, Marketplaces, Tools), throttled with a 30-second TTL per tab to avoid constant refetching/flicker while navigating. A loading indicator is shown across tabs (including Sync) while refresh is in progress.
+Blackbook performs one startup scan, then refreshes only when requested manually with `R` on each tab. A loading indicator is shown across tabs (including Sync) while refresh is in progress.
 
 ## Configuration
 
@@ -124,7 +124,6 @@ settings:
   source_repo: ~/src/playbook
   package_manager: pnpm     # npm | pnpm | bun
   backup_retention: 3       # Number of backups to keep per file (1-100)
-  default_pullback: false   # Enable pullback for new file entries
 
 tools:
   claude-code:
@@ -141,7 +140,6 @@ files:
   - name: CLAUDE.md
     source: CLAUDE.md         # Relative to source_repo
     target: CLAUDE.md
-    pullback: true            # Enable three-way state tracking
     overrides:
       "opencode:default": AGENTS.md
   - name: Settings
@@ -179,12 +177,11 @@ The `files:` list manages all synced files in a single unified list:
 |---------|-------------|
 | `tools` omitted | Syncs to all enabled, syncable tool instances |
 | `tools: [claude-code]` | Syncs only to claude-code instances |
-| `pullback: true` | Enables three-way state tracking for reverse sync |
 | `overrides` | Per-instance target path overrides |
 
 #### Three-Way State
 
-Files with `pullback: true` use deterministic hash-based drift detection instead of timestamps:
+Managed files use deterministic hash-based drift detection instead of timestamps:
 
 | Drift | Meaning | Action |
 |-------|---------|--------|

--- a/docs/TEST_COVERAGE.md
+++ b/docs/TEST_COVERAGE.md
@@ -3,8 +3,8 @@
 This project tracks coverage by critical user journeys and system boundaries.
 
 ## Test Suite Summary
-- **Total Tests:** 319
-- **Test Files:** 32
+- **Total Tests:** 447
+- **Test Files:** 40
 
 ## Critical Paths
 - [x] Plugin discovery list loads

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -240,3 +240,10 @@ Each phase is independently shippable and testable.
 - Centralized zero-diff rendering behavior in shared `ItemDetail` action row: diff counts are shown only when non-zero, preventing noisy `Changed +0 -0` across plugin/file detail views.
 - Installed tab now has per-section loading placeholder consistency for Files too (`filesLoaded`), matching Plugins/Pi Packages behavior and avoiding awkward late file population.
 
+## Release Prep (v0.18.0)
+- [x] Bump `tui/package.json` version to `0.18.0`
+- [x] Add `0.18.0` release notes section in `CHANGELOG.md` and update compare links
+- [x] Align key docs (`README.md`, `docs/TEST_COVERAGE.md`) with current behavior/metrics
+- [x] Run quality gates (`pnpm typecheck`, `pnpm test`, `pnpm build`)
+- [x] Commit and push release-prep changes
+

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssweens/blackbook",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "description": "Plugin manager for AI coding tools",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary\n- bump tui package version to 0.18.0\n- add 0.18.0 changelog section and compare links\n- refresh README details for current refresh/pullback/tool-path behavior\n- update TEST_COVERAGE suite totals\n\n## Validation\n- cd tui && pnpm typecheck\n- cd tui && pnpm test\n- cd tui && pnpm build\n\n## Merge\nUse normal merge commit (no squash).