### PR TITLE
refactor: unified item model architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] - 2026-03-11
+
+### Fixed
+- Source repo status now refreshes immediately after pullback — `refreshAll()` clears the git status cache so Settings reflects repo changes without waiting for the 60-second TTL or restarting the app.
+
 ## [0.18.0] - 2026-03-10
 
 ### Added

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssweens/blackbook",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Plugin manager for AI coding tools",
   "license": "Apache-2.0",
   "repository": {

--- a/tui/src/lib/source-setup.ts
+++ b/tui/src/lib/source-setup.ts
@@ -280,7 +280,7 @@ function setSourceStatusCache(value: SourceRepoStatus | null): void {
   sourceStatusCache = { value, at: Date.now() };
 }
 
-function clearSourceStatusCache(): void {
+export function clearSourceStatusCache(): void {
   sourceStatusCache = null;
 }
 

--- a/tui/src/lib/store.ts
+++ b/tui/src/lib/store.ts
@@ -42,7 +42,7 @@ import {
 } from "./config.js";
 import { loadConfig as loadYamlConfig, getConfigPath as getYamlConfigPath } from "./config/loader.js";
 import { resolveSourcePath, expandPath as expandConfigPath } from "./config/path.js";
-import { pullSourceRepo, primeSourceRepoStatus } from "./source-setup.js";
+import { pullSourceRepo, primeSourceRepoStatus, clearSourceStatusCache } from "./source-setup.js";
 import { getAllPlaybooks, resolveToolInstances, isSyncTarget } from "./config/playbooks.js";
 import { runCheck, runApply } from "./modules/orchestrator.js";
 import { fileCopyModule } from "./modules/file-copy.js";
@@ -1211,6 +1211,7 @@ export const useStore = create<Store>((set, get) => ({
   },
 
   refreshAll: async () => {
+    clearSourceStatusCache();
     await get().loadMarketplaces();
     await get().refreshToolDetection();
     await get().loadPiPackages();


### PR DESCRIPTION
## Summary
- Unified item architecture (`ManagedItem`) replacing 8 bespoke list/detail components with generic `ItemList` and `ItemDetail`
- Centralized action dispatch (`handleItemAction`) replacing 3 separate action handlers
- Unified marketplace presentation merging plugin and Pi marketplace flows into a single module
- Plugin pullback workflow with drift detection and aligned keyboard shortcuts
- Source repo status cache fix: `refreshAll()` now clears stale git status immediately after pullbacks

## Key Changes
- **-3,761 / +5,715 lines** across 48 files — net reduction in App.tsx from ~2,500 to ~1,735 lines
- Deleted 8 orphaned components (AssetList, ConfigList, FileDetail, FileList, MarketplaceDetail, PiMarketplaceDetail, PiMarketplaceList, PiPackageDetail, PiPackageList, PluginDetail, PluginList)
- Extracted reusable modules: `action-dispatch.ts`, `input-hooks.ts`, `item-actions.ts`, `managed-item.ts`, `item-drift.ts`, `path-utils.ts`, `marketplace-detail.ts`, `marketplace-row.ts`
- Collapsed 28 useState hooks to 20, extracted 5 input handlers reducing useInput from 604 to 223 lines (-63%)
- Refresh model simplified to startup scan + manual refresh only (removed navigation-triggered and watcher-driven auto-refresh)

## Test plan
- [x] All 447 tests pass (40 test files)
- [x] New test coverage: `ItemList`, `ItemDetail`, `action-dispatch`, `managed-item`, `item-drift`, `marketplace-detail`, `marketplace-row`
- [x] E2E tests cover tab navigation, plugin/file/pi-package detail views, drift badges, sync tab, marketplace browsing
- [x] Verified pullback triggers immediate Settings refresh (the v0.18.1 fix)